### PR TITLE
Add support for executing a command when deactivating

### DIFF
--- a/README
+++ b/README
@@ -8,12 +8,18 @@ SYNOPSIS
 
 DESCRIPTION
      xssstart runs the specified command on XScreenSaver(3) ScreenSaverOn
-     events.  As long as the command is running, further events are ignored.
+     events.  An additional command can be specified for ScreenSaverOff
+     events. Separate the commands with a -- argument.  As long as a command
+     is running, further events are ignored.
 
 EXAMPLES
      xssstart xlock -mode blank &
              Starts xssstart in the background, running xlock(1) in blank mode
              when the screen saver activates.
+
+     xssstart xlock -mode blank -- aplay unblank.wav &
+             Does the same but also plays unblank.wav when the screen saver
+             deactivates.
 
      xset s 600
              Sets the screen saver parameters to activate after 600 seconds of

--- a/xssstart.1
+++ b/xssstart.1
@@ -28,7 +28,8 @@ runs the specified command on
 .Xr XScreenSaver 3
 .Li ScreenSaverOn
 events.
-As long as the command is running, further events are ignored.
+An additional command can be specified for ScreenSaverOff events. Separate the commands with a -- argument.
+As long as a command is running, further events are ignored.
 .Sh EXAMPLES
 .Bl -tag -width indent
 .It Li "xssstart xlock -mode blank &"
@@ -37,6 +38,8 @@ Starts
 in the background, running
 .Xr xlock 1
 in blank mode when the screen saver activates.
+.It Li "xssstart xlock -mode blank -- aplay unblank.wav &"
+Does the same but also plays unblank.wav when the screen saver deactivates.
 .It Li "xset s 600"
 Sets the screen saver parameters to activate after 600 seconds of inactivity.
 .It Li "xset s activate"


### PR DESCRIPTION
This is specified by separating the two commands with a `--` argument. Giving a deactivate command without an activate command is allowed.

My groff knowledge is practically non-existent and I didn't know how to format the synopsis like I have in the usage text so I'll leave that to you.

I made this change because I want to use xrandr to turn off one monitor while leaving the other on. DPMS in X11 is global so you can't use it to do that. Infuriatingly, this didn't work because it seems that screensaver events are not emitted when the monitor is off so it never comes back on.